### PR TITLE
Scene refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,62 @@
-Getting started on writing a renderer based on https://raytracing.github.io/books/RayTracingInOneWeekend.html
+This is the second release version of my ray_tracing 
+project! The next release will feature animations and
+will be a major departure from the book: 
 
-Unlike that book I am writing it in Rust! 
+https://raytracing.github.io/books/RayTracingInOneWeekend.html
+
+Here is a list of current features:
+    - Path-tracing rendering
+    - Some material and texture support for objects
+    - Multithreading on the CPU
+    - Minimal Obj file support
+    - Spherical skybox mapping
+    - Aliased scene elements for future editing support
+Here are some planned features:
+    - Offline animation rendering
+    - Physics driven manipulation of scene elements
+    - GPU edition
+    - Programming language interface with static checking
+    - A pre-vis app to edit scene programs visually before
+        render
+    - And probably a lot more!
+
+TODO: Write a better how to use section here!
+
+This program can be run with a few command line arguments
+and one environment variable.
+
+To change the place to look for assets from the default
+you may define the environment variable `ASSET_DIR`. This
+directory is where the program will search to load files
+from. Alternatively it will default to searching through
+a few directory levels for a directory called `assets`.
+
+The program also takes a few command line arguments:
+
+-f or --file    Specifies the file to render the image to
+-t or --threads Specifies the number of threads to use      
+                (defaults to the systems number of threads)
+-w or --word    Selects a scene to render from the demo 
+                scenes. These are as follows:
+                    1. A scene from the end of the book
+                    2. The same as above but with motion 
+                        blur
+                    3. A scene with two checkered spheres
+                    4. A scene with the Utah teapot
+                    5. A scene with a sphere wrapped with an
+                        earth texture
+                    6. A scene featuring a skybox
+
+Try rendering these scenes or make your own! While this
+may be clunky for the time being this will become easier in
+the next release which will add a scripting language for
+efficiently building scenes and movies. 
+
+Finally this project is a work in progress and things
+may not work exactly as expected. Feel free to open issues
+and I will get to them as soon as possible!
+
+The Sponza dragon scene has not been built yet in favor of
+this detour. But when it is the asset is acquired from:
+
+Sponza Dragon asset from Marko Dabrovic sourced at http://hdri.cgtechniques.com/~sponza/files/

--- a/benches/renderer_benchmark.rs
+++ b/benches/renderer_benchmark.rs
@@ -9,35 +9,35 @@ pub fn rendering_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Threaded Rendering");
     group.sample_size(10);
 
-    let (world, mut cam) = demo_scenes::book1_end_scene(1);
+    let mut scene = demo_scenes::book1_end_scene(1);
 
     // 1
     group.bench_function("render one thread", |b| {
-        b.iter(|| cam.render(std::hint::black_box(&world), "benches/criterion_bench.ppm"))
+        b.iter(|| scene.render_scene("benches/criterion_bench.ppm"))
     });
 
     // 2
     let threads = thread::available_parallelism().unwrap().get();
-    cam.set_threads(threads);
+    scene.scene_cam.set_threads(threads);
 
     group.bench_function("render sys thread", |b| {
-        b.iter(|| cam.render(std::hint::black_box(&world), "benches/criterion_bench.ppm"))
+        b.iter(|| scene.render_scene("benches/criterion_bench.ppm"))
     });
 
     // 3
     let threads = thread::available_parallelism().unwrap().get() / 2;
-    cam.set_threads(threads);
+    scene.scene_cam.set_threads(threads);
 
     group.bench_function("render half sys thread", |b| {
-        b.iter(|| cam.render(std::hint::black_box(&world), "benches/criterion_bench.ppm"))
+        b.iter(|| scene.render_scene("benches/criterion_bench.ppm"))
     });
 
     // 4
     let threads = thread::available_parallelism().unwrap().get() * 2;
-    cam.set_threads(threads);
+    scene.scene_cam.set_threads(threads);
 
     group.bench_function("render double sys thread", |b| {
-        b.iter(|| cam.render(std::hint::black_box(&world), "benches/criterion_bench.ppm"))
+        b.iter(|| scene.render_scene("benches/criterion_bench.ppm"))
     });
 
     let _ = fs::remove_file("benches/criterion_bench.ppm");

--- a/src/asset_loader.rs
+++ b/src/asset_loader.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use dashmap::DashMap;
-use image::{ImageFormat, Pixel};
+use image::ImageFormat;
 
 use crate::{
     material::{Lambertian, Materials},
@@ -206,8 +206,8 @@ impl RTWImage {
         let format = ImageFormat::from_path(&image_filename).expect("Unsupported filetype");
         let reader = BufReader::new(File::open(image_filename).unwrap());
 
-        let mut image = image::load(reader, format).expect("Cannot read image");
-        let image = image.as_mut_rgb8().unwrap();
+        let image = image::load(reader, format).expect("Cannot read image");
+        let image = image.to_rgb8();
 
         // Loop over the image and populate the dashmap
         let image_height = image.height();
@@ -215,25 +215,13 @@ impl RTWImage {
 
         let colors = DashMap::with_capacity((image_height * image_width) as usize);
 
-        dbg!(image_width);
-        dbg!(image_height);
-
         for h in 0..image_height {
             for w in 0..image_width {
                 let pixel = image.get_pixel(w, h);
 
-                let rgb = pixel.to_rgb();
-
-                if rgb.0 == [46, 73, 2] {
-                    eprintln!("Landho");
-                    eprint!("r {}", rgb.0[0] as f64 / 255.0);
-                    eprint!("g {}", rgb.0[1] as f64 / 255.0);
-                    eprintln!("b {}", rgb.0[2] as f64 / 255.0);
-                    eprintln!("{w} {h}");
-                }
-                let r = rgb.0[0] as f64 / 255.0;
-                let g = rgb.0[1] as f64 / 255.0;
-                let b = rgb.0[2] as f64 / 255.0;
+                let r = pixel.0[0] as f64 / 255.0;
+                let g = pixel.0[1] as f64 / 255.0;
+                let b = pixel.0[2] as f64 / 255.0;
 
                 colors.insert((w as usize, h as usize), Color::new(r, g, b));
             }

--- a/src/demo_scenes.rs
+++ b/src/demo_scenes.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use rand::Rng;
 
 use crate::{
-    asset_loader,
     material::{Dielectric, Lambertian, Materials, Metal},
     objects::{Hittables, Sphere},
     scene::Scene,
@@ -33,16 +32,18 @@ pub fn book1_end_scene(threads: usize) -> Scene {
     )));
 
     let ground_material = Materials::Lambertian(Lambertian::new_from_texture(checker, 1.0));
-    b1_scene
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b1_scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(0.0, -1000.0, 0.0),
             1000.0,
             ground_material,
-        )));
+        )),
+        "ground",
+    );
 
     // rng to pick material
     let mut rng = rand::rng();
+    let mut counter = 0;
 
     for a in -11..11 {
         for b in -11..11 {
@@ -59,67 +60,62 @@ pub fn book1_end_scene(threads: usize) -> Scene {
                     let albedo = Color::random_color() * Color::random_color();
                     let sphere_material =
                         Materials::Lambertian(Lambertian::new_from_color(albedo, 1.0));
-                    b1_scene
-                        .elements
-                        .add(Hittables::Sphere(Sphere::new_stationary(
-                            center,
-                            0.2,
-                            sphere_material,
-                        )));
+                    b1_scene.add_element(
+                        Hittables::Sphere(Sphere::new_stationary(center, 0.2, sphere_material)),
+                        &("small".to_string() + &counter.to_string()),
+                    );
                 } else if choose_mat < 0.95 {
                     // metal
                     let albedo = Color::random_color_range(0.5, 1.0);
                     let fuzz = rng.random_range(0.0..0.5);
                     let sphere_material = Materials::Metal(Metal::new(albedo, fuzz));
-                    b1_scene
-                        .elements
-                        .add(Hittables::Sphere(Sphere::new_stationary(
-                            center,
-                            0.2,
-                            sphere_material,
-                        )));
+                    b1_scene.add_element(
+                        Hittables::Sphere(Sphere::new_stationary(center, 0.2, sphere_material)),
+                        &("small".to_string() + &counter.to_string()),
+                    );
                 } else {
                     // glass
                     let sphere_material = Materials::Dielectric(Dielectric::new(1.5));
-                    b1_scene
-                        .elements
-                        .add(Hittables::Sphere(Sphere::new_stationary(
-                            center,
-                            0.2,
-                            sphere_material,
-                        )));
+                    b1_scene.add_element(
+                        Hittables::Sphere(Sphere::new_stationary(center, 0.2, sphere_material)),
+                        &("small".to_string() + &counter.to_string()),
+                    );
                 }
+                counter += 1;
             }
         }
     }
 
     let material1 = Materials::Dielectric(Dielectric::new(1.5));
-    b1_scene
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b1_scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(0.0, 1.0, 0.0),
             1.0,
             material1,
-        )));
+        )),
+        "large_dielectric",
+    );
 
     let material2 =
         Materials::Lambertian(Lambertian::new_from_color(Color::new(0.4, 0.2, 0.1), 1.0));
-    b1_scene
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b1_scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(-4.0, 1.0, 0.0),
             1.0,
             material2,
-        )));
+        )),
+        "large_lambertian",
+    );
 
     let material3 = Materials::Metal(Metal::new(Color::new(0.7, 0.6, 0.5), 0.0));
-    b1_scene
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b1_scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(4.0, 1.0, 0.0),
             1.0,
             material3,
-        )));
+        )),
+        "large_metal",
+    );
 
     b1_scene
 }
@@ -147,16 +143,18 @@ pub fn book2_motion_blur_scene(threads: usize) -> Scene {
     )));
 
     let ground_material = Materials::Lambertian(Lambertian::new_from_texture(checker, 1.0));
-    b2_motion
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b2_motion.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(0.0, -1000.0, 0.0),
             1000.0,
             ground_material,
-        )));
+        )),
+        "ground",
+    );
 
     // rng to pick material
     let mut rng = rand::rng();
+    let mut counter = 0;
 
     for a in -11..11 {
         for b in -11..11 {
@@ -174,66 +172,67 @@ pub fn book2_motion_blur_scene(threads: usize) -> Scene {
                     let sphere_material =
                         Materials::Lambertian(Lambertian::new_from_color(albedo, 1.0));
                     let center2 = center.clone() + Vec3::new(0.0, rng.random_range(0.0..0.5), 0.0);
-                    b2_motion.elements.add(Hittables::Sphere(Sphere::new_moving(
-                        center,
-                        center2,
-                        0.2,
-                        sphere_material,
-                    )));
+                    b2_motion.add_element(
+                        Hittables::Sphere(Sphere::new_moving(
+                            center,
+                            center2,
+                            0.2,
+                            sphere_material,
+                        )),
+                        &("small".to_string() + &counter.to_string()),
+                    );
                 } else if choose_mat < 0.95 {
                     // metal
                     let albedo = Color::random_color_range(0.5, 1.0);
                     let fuzz = rng.random_range(0.0..0.5);
                     let sphere_material = Materials::Metal(Metal::new(albedo, fuzz));
-                    b2_motion
-                        .elements
-                        .add(Hittables::Sphere(Sphere::new_stationary(
-                            center,
-                            0.2,
-                            sphere_material,
-                        )));
+                    b2_motion.add_element(
+                        Hittables::Sphere(Sphere::new_stationary(center, 0.2, sphere_material)),
+                        &("small".to_string() + &counter.to_string()),
+                    );
                 } else {
                     // glass
                     let sphere_material = Materials::Dielectric(Dielectric::new(1.5));
-                    b2_motion
-                        .elements
-                        .add(Hittables::Sphere(Sphere::new_stationary(
-                            center,
-                            0.2,
-                            sphere_material,
-                        )));
+                    b2_motion.add_element(
+                        Hittables::Sphere(Sphere::new_stationary(center, 0.2, sphere_material)),
+                        &("small".to_string() + &counter.to_string()),
+                    );
                 }
+                counter += 1;
             }
         }
     }
 
     let material1 = Materials::Dielectric(Dielectric::new(1.5));
-    b2_motion
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b2_motion.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(0.0, 1.0, 0.0),
             1.0,
             material1,
-        )));
+        )),
+        "large_dielectric",
+    );
 
     let material2 =
         Materials::Lambertian(Lambertian::new_from_color(Color::new(0.4, 0.2, 0.1), 1.0));
-    b2_motion
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b2_motion.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(-4.0, 1.0, 0.0),
             1.0,
             material2,
-        )));
+        )),
+        "large_lambertian",
+    );
 
     let material3 = Materials::Metal(Metal::new(Color::new(0.7, 0.6, 0.5), 0.0));
-    b2_motion
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    b2_motion.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(4.0, 1.0, 0.0),
             1.0,
             material3,
-        )));
+        )),
+        "large_metal",
+    );
 
     b2_motion
 }
@@ -260,17 +259,23 @@ pub fn checkered_spheres(threads: usize) -> Scene {
         Color::new(0.9, 0.9, 0.9),
     )));
 
-    scene.elements.add(Hittables::Sphere(Sphere::new_stationary(
-        Point3::new(0.0, -10.0, 0.0),
-        10.0,
-        Materials::Lambertian(Lambertian::new_from_texture(checker.clone(), 1.0)),
-    )));
+    scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
+            Point3::new(0.0, -10.0, 0.0),
+            10.0,
+            Materials::Lambertian(Lambertian::new_from_texture(checker.clone(), 1.0)),
+        )),
+        "bottom_sphere",
+    );
 
-    scene.elements.add(Hittables::Sphere(Sphere::new_stationary(
-        Point3::new(0.0, 10.0, 0.0),
-        10.0,
-        Materials::Lambertian(Lambertian::new_from_texture(checker, 1.0)),
-    )));
+    scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
+            Point3::new(0.0, 10.0, 0.0),
+            10.0,
+            Materials::Lambertian(Lambertian::new_from_texture(checker, 1.0)),
+        )),
+        "top_sphere",
+    );
 
     scene
 }
@@ -293,13 +298,7 @@ pub fn load_teapot(threads: usize) -> Scene {
     teapot_scene.scene_cam.set_focus_dist(10.0);
 
     // add the teapot
-    teapot_scene
-        .elements
-        .add(Hittables::HitList(asset_loader::load_obj(
-            "teapot.obj",
-            0.5,
-            Point3::new(3.0, 0.0, 0.0),
-        )));
+    teapot_scene.load_asset("teapot.obj", "teapot", 0.5, Point3::new(3.0, 0.0, 0.0));
 
     // add the ground
     let checker = Arc::new(Textures::CheckerTexture(CheckerTexture::new_from_color(
@@ -309,15 +308,15 @@ pub fn load_teapot(threads: usize) -> Scene {
     )));
 
     let ground_material = Materials::Lambertian(Lambertian::new_from_texture(checker, 1.0));
-    teapot_scene
-        .elements
-        .add(Hittables::Sphere(Sphere::new_stationary(
+    teapot_scene.add_element(
+        Hittables::Sphere(Sphere::new_stationary(
             Point3::new(0.0, -1000.0, 0.0),
             1000.0,
             ground_material,
-        )));
+        )),
+        "ground",
+    );
 
-    // Make cam mutable to change its behaviors
     teapot_scene
 }
 
@@ -341,7 +340,7 @@ pub fn earth(threads: usize) -> Scene {
         earth_surface,
     ));
 
-    earth_scene.elements.add(globe);
+    earth_scene.add_element(globe, "earth");
 
     earth_scene
 }
@@ -357,14 +356,14 @@ pub fn garden_skybox(threads: usize) -> Scene {
 
     garden.scene_cam.set_vfov(40.0);
 
-    let earth_surface = Materials::Metal(Metal::new(Color::new(0.8, 0.8, 0.8), 0.05));
-    let globe = Hittables::Sphere(Sphere::new_stationary(
+    let test_ball = Materials::Metal(Metal::new(Color::new(0.8, 0.8, 0.8), 0.05));
+    let ball = Hittables::Sphere(Sphere::new_stationary(
         Point3::new(0.0, 0.0, 0.0),
         2.0,
-        earth_surface,
+        test_ball,
     ));
 
-    garden.elements.add(globe);
+    garden.add_element(ball, "metal_ball");
 
     garden.load_spherical_skybox("garden.hdr");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
-pub mod asset_loader;
+mod asset_loader;
+mod camera;
+mod material;
+mod objects;
+mod texture;
+
 pub mod demo_scenes;
-pub mod camera;
-pub mod material;
-pub mod objects;
-pub mod texture;
+pub mod scene;
 pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,13 @@ fn main() {
 
     let threads = args.threads.unwrap_or(std::thread::available_parallelism().expect("Cannot get the thread count of your system. Specify one when running this program.").get());
 
-    let (world, mut cam) = match args.world {
+    let scene = match args.world {
         1 => demo_scenes::book1_end_scene(threads),
         2 => demo_scenes::book2_motion_blur_scene(threads),
         3 => demo_scenes::checkered_spheres(threads),
         4 => demo_scenes::load_teapot(threads),
         5 => demo_scenes::earth(threads),
+        6 => demo_scenes::garden_skybox(threads),
         _ => {
             eprintln!("Invalid world number. Selecting default scene");
             demo_scenes::book1_end_scene(threads)
@@ -36,12 +37,5 @@ fn main() {
 
     eprintln!("Creating camera with {threads} threads.");
 
-    match cam.render(&world, args.file.as_str()) {
-        Ok(()) => {
-            eprintln!("Successful render! Image stored at: {}", args.file.as_str());
-        }
-        Err(e) => {
-            eprintln!("Render failed. {e}");
-        }
-    }
+    scene.render_scene(args.file.as_str());
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,9 +1,12 @@
 use crate::{
-    asset_loader::RTWImage,
+    asset_loader::{self, RTWImage},
     camera::Camera,
-    objects::{BVHWrapper, HitList},
-    util::{Color, Interval},
+    objects::{BVHWrapper, HitList, Hittables},
+    scene::id_vendor::IdVendor,
+    util::{Color, Interval, Point3},
 };
+
+mod id_vendor;
 
 /// The types of skyboxes that can be used in a scene
 /// Currently only Spherical is supported.
@@ -45,9 +48,10 @@ impl SkyboxImage {
 /// render unless you know what you are doing.
 pub struct Scene {
     pub scene_cam: Camera,
-    pub elements: HitList,
+    elements: HitList,
     skybox: Skybox,
     frame: u32,
+    id_vendor: IdVendor,
 }
 
 impl Scene {
@@ -61,6 +65,7 @@ impl Scene {
             elements,
             skybox,
             frame: 0,
+            id_vendor: IdVendor::new(),
         }
     }
 
@@ -74,6 +79,121 @@ impl Scene {
         let image = RTWImage::new(file);
 
         self.skybox = Skybox::Spherical(SkyboxImage { image });
+    }
+
+    /// Adds an element to the scene with a name of {alias}
+    pub fn add_element(&mut self, element: Hittables, alias: &str) {
+        match element {
+            Hittables::BVHWrapper(_) => {
+                self.elements.add(element);
+            }
+            Hittables::HitList(_) => {
+                self.elements.add(element);
+            }
+            Hittables::Sphere(mut s) => {
+                let internal_id = self.id_vendor.vend_id(alias);
+                if internal_id.is_none() {
+                    panic!(
+                        "This sphere's alias collides with another name in the scene! Try changing {alias} to a new name."
+                    );
+                }
+                s.id = internal_id.unwrap();
+                self.elements.add(Hittables::Sphere(s));
+            }
+            Hittables::Triangle(mut t) => {
+                let internal_id = self.id_vendor.vend_id(alias);
+                if internal_id.is_none() {
+                    panic!(
+                        "This triangles's alias collides with another name in the scene! Try changing {alias} to a new name."
+                    );
+                }
+                t.id = internal_id.unwrap();
+                self.elements.add(Hittables::Triangle(t));
+            }
+        }
+    }
+
+    /// Loads an asset from an obj file, and gives it a name of {alias}
+    pub fn load_asset(&mut self, asset_path: &str, alias: &str, scale: f64, shift: Point3) {
+        // Check for collisions
+        let internal_id = self.id_vendor.vend_id(alias);
+        if internal_id.is_none() {
+            panic!(
+                "This mesh's alias collides with another name in the scene! Try changing {alias} to a new name."
+            )
+        }
+
+        // Load mesh
+        let triangle_mesh = asset_loader::load_obj(asset_path, scale, shift);
+
+        // Flatten the mesh since the id keeps them associated
+        for element in triangle_mesh.get_objs() {
+            let element = element.clone();
+            match element {
+                Hittables::BVHWrapper(_) => {
+                    self.elements.add(element);
+                }
+                Hittables::HitList(_) => {
+                    self.elements.add(element);
+                }
+                Hittables::Sphere(mut s) => {
+                    s.id = internal_id.unwrap();
+                    self.elements.add(Hittables::Sphere(s));
+                }
+                Hittables::Triangle(mut t) => {
+                    t.id = internal_id.unwrap();
+                    self.elements.add(Hittables::Triangle(t));
+                }
+            }
+        }
+    }
+
+    /// Makes an item with {alias} visible in the render
+    pub fn show_element(&mut self, alias: &str) {
+        self.set_visibility(alias, false);
+    }
+
+    pub fn hide_element(&mut self, alias: &str) {
+        self.set_visibility(alias, true);
+    }
+
+    // TODO: Check performance here
+    fn set_visibility(&mut self, alias: &str, hide: bool) {
+        let mut updated_list = HitList::default();
+        let internal_id = self.id_vendor.alias_lookup(alias);
+
+        if internal_id.is_none() {
+            eprintln!(
+                "WARNING: The element `{alias}` does not exist. Are you sure you typed the right name?"
+            );
+            return;
+        }
+
+        let internal_id = internal_id.unwrap();
+
+        for element in self.elements.get_objs().clone() {
+            // Check if the element has the internal id
+            let updated = match element {
+                // These first cases shouldn't happen since the scenes structure is flat
+                Hittables::BVHWrapper(_) => element,
+                Hittables::HitList(_) => element,
+                Hittables::Sphere(mut s) => {
+                    if s.id == internal_id {
+                        s.hide = hide
+                    }
+                    Hittables::Sphere(s)
+                }
+                Hittables::Triangle(mut t) => {
+                    if t.id == internal_id {
+                        t.hide = hide
+                    }
+                    Hittables::Triangle(t)
+                }
+            };
+            updated_list.add(updated);
+        }
+
+        self.elements = updated_list;
     }
 
     /// Advances the scene forward one frame, when

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,0 +1,102 @@
+use crate::{
+    asset_loader::RTWImage,
+    camera::Camera,
+    objects::{BVHWrapper, HitList},
+    util::{Color, Interval},
+};
+
+/// The types of skyboxes that can be used in a scene
+/// Currently only Spherical is supported.
+#[derive(Debug, Clone)]
+pub enum Skybox {
+    Spherical(SkyboxImage),
+    //Planar(SkyboxImage),
+    //Triplanar(SkyboxImage),
+    //CameraMapping(SkyboxImage),
+    Default,
+}
+
+/// TODO: Maybe make get_color a method on a skybox and it
+/// just computes it for the camera?
+#[derive(Debug, Clone)]
+pub struct SkyboxImage {
+    image: RTWImage,
+}
+
+impl SkyboxImage {
+    /// Take the uv coordinate mapping and convert it to
+    /// pixel mapping in the skybox image.
+    pub fn get_color(&self, u: f64, v: f64) -> Color {
+        let u = Interval::new(0.0, 1.0).clamp(u);
+        let v = 1.0 - Interval::new(0.0, 1.0).clamp(v);
+
+        let i = (u * self.image.width() as f64) as usize;
+        let j = (v * self.image.height() as f64) as usize;
+
+        self.image.pixel_data(i, j)
+    }
+}
+
+/// A scene holds a camera, elements, a skybox, and the
+/// current frame of a render. The scene will move objects
+/// around if they are moveable as the time changes. This
+/// can be used to render many images with small adjustments
+/// for film making purposes. WARNING: Do not directly call
+/// render unless you know what you are doing.
+pub struct Scene {
+    pub scene_cam: Camera,
+    pub elements: HitList,
+    skybox: Skybox,
+    frame: u32,
+}
+
+impl Scene {
+    pub fn new(aspect_ratio: f64, image_width: u32, thread_count: usize) -> Scene {
+        let scene_cam = Camera::new(aspect_ratio, image_width, thread_count);
+        let elements = HitList::default();
+        let skybox = Skybox::Default;
+
+        Scene {
+            scene_cam,
+            elements,
+            skybox,
+            frame: 0,
+        }
+    }
+
+    /// Sets the skybox to the default LERP between white
+    /// and blue
+    pub fn load_default_skybox(&mut self) {
+        self.skybox = Skybox::Default
+    }
+
+    pub fn load_spherical_skybox(&mut self, file: &str) {
+        let image = RTWImage::new(file);
+
+        self.skybox = Skybox::Spherical(SkyboxImage { image });
+    }
+
+    /// Advances the scene forward one frame, when
+    /// render scene is called this value will augment where
+    /// the objects are. TODO consider frame rates
+    pub fn advance_frame(&mut self) {
+        self.frame += 1;
+    }
+
+    /// Render scene wraps the HitList before rendering
+    /// Scenes keep this unwrapped before rendering for
+    /// easy alteration when working with movie type renders
+    pub fn render_scene(&self, fname: &str) {
+        let world = BVHWrapper::new_wrapper(self.elements.clone());
+
+        // Get rid of the prints soon
+        match self.scene_cam.render(&self.skybox, &world, fname) {
+            Ok(()) => {
+                eprintln!("Successful render! Image stored at: {fname}");
+            }
+            Err(e) => {
+                eprintln!("Render failed. {e}");
+            }
+        }
+    }
+}

--- a/src/scene/id_vendor.rs
+++ b/src/scene/id_vendor.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+/// IdVendor deals a usize value and stores the string that
+/// maps to it. This allows aliasing of objects which
+/// is especially important for triangle mesh maps
+pub struct IdVendor {
+    id_map: HashMap<String, usize>,
+    id_to_vend: usize,
+}
+
+impl IdVendor {
+    pub fn new() -> IdVendor {
+        IdVendor { id_map: HashMap::new(), id_to_vend: 0 }
+    }
+
+    /// Returns a unique ID for an alias. Returns None
+    /// if the alias is already used.
+    pub fn vend_id(&mut self, alias: &str) -> Option<usize> {
+        let alias = alias.to_string();
+
+        if self.id_map.contains_key(&alias) {
+            return None;
+        }
+
+        self.id_map.insert(alias, self.id_to_vend);
+
+        let obj_id = self.id_to_vend;
+        self.id_to_vend += 1;
+
+        Some(obj_id)
+    }
+
+    /// Looks up the id of an alias
+    pub fn alias_lookup(&self, alias: &str) -> Option<usize> {
+        let alias = alias.to_string();
+        self.id_map.get(&alias).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_collision() {
+        let mut vendor = IdVendor::new();
+
+        let id = vendor.vend_id("test_var");
+        assert!(id.is_some());
+
+        let id2 = vendor.vend_id("test_var");
+        assert!(id2.is_none());
+    }
+
+    #[test]
+    fn alias_coherence() {
+        let mut vendor = IdVendor::new();
+
+        let id = vendor.vend_id("test_var");
+        let id2 = vendor.alias_lookup("test_var");
+
+        assert_eq!(id, id2);
+    }
+}

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -118,10 +118,6 @@ impl Texture for ImageTexture {
         let i = (u * self.image.width() as f64) as usize;
         let j = (v * self.image.height() as f64) as usize;
 
-        if i == 562 && j == 241 {
-            eprintln!("Making land");
-        }
-
         self.image.pixel_data(i, j)
     }
 }


### PR DESCRIPTION
This is some cleanup work to organize scenes better for future development. Flattening the triangle HitList in the scenes seems to have helped BVH  greatly. This and many other future changes have been enabled via element aliasing. Elements now have an associated name at a scene level. This currently enables elements to be hidden but will also power the transform feature and the programming language bindings into the renderer. 

The scene abstraction enables scenes to have attached sky-boxes. While hypothetically the user could change the sky-box each frame and make a jarring 
experience for the viewer this abstraction seems a good metaphor for movie making.

Performance has been continuously trending downwards, after animations it may be time to seriously look into rust-gpu for accelerator based path tracing.

Finally while documentation is still lacking this pull request has a more complete README so that someone who stumbles onto this repo could try it even in its current fledgling state.